### PR TITLE
Added Select-AzureRmSubscription to automationAccountsScriptBlock

### DIFF
--- a/Scripts/Setup.ps1
+++ b/Scripts/Setup.ps1
@@ -80,6 +80,7 @@ param
     )
 
     Add-AzureRmAccount -Credential $cred
+    Select-AzureRmSubscription -SubscriptionId $SubscriptionId
 
     New-AzureRmImgMgmtAutomationAccount -automationAccountName $automationAccountName `
         -resourceGroupName $resourceGroupName `


### PR DESCRIPTION
With multiple subscriptions I found that the Automation Accounts were being created in the tier 2 subscription. This was because when executing Add-AzureRmccount using my account it defaulted to the Tier2 Subscription. Since there is no long a way to set a default subscription (that I know of) it is pretty much mandatory to run Seletct-AzureRmSubscription after Add-AzureRmAccount.